### PR TITLE
[Remove] MonthView의 onEventTap 기능 제거

### DIFF
--- a/lib/src/month_view/month_view.dart
+++ b/lib/src/month_view/month_view.dart
@@ -514,7 +514,8 @@ class MonthViewState<T extends Object?> extends State<MonthView<T>> {
       shouldHighlight: isToday,
       backgroundColor: isInMonth ? Constants.white : Constants.offWhite,
       events: events,
-      onTileTap: widget.onEventTap,
+      // onTileTap: widget.onEventTap,
+      onTileTap: widget.onCellTap,
       dateStringBuilder: widget.dateStringBuilder,
     );
   }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

기존에 존재하던 달력 날짜에 있는 텍스트 이벤트를 클릭시 클릭한 이벤트만 보이는 기능을 제거함
즉, MonthView의 onEventTap이 작동하지 않도록 변경
